### PR TITLE
Fix saving search appearance tab lose setting value

### DIFF
--- a/src/Yoast_Purge_Control_Yoast_SEO_Settings.php
+++ b/src/Yoast_Purge_Control_Yoast_SEO_Settings.php
@@ -5,6 +5,28 @@
  */
 class Yoast_Purge_Control_Yoast_SEO_Settings {
 	/**
+	 * Adds WordPress hooks and filters.
+	 *
+	 * @return void
+	 */
+	public function register_hooks() {
+		add_filter( 'wpseo_option_tab-metas_media', array( $this, 'add_hidden_settings' ) );
+	}
+
+	/**
+	 * Adds the setting to the media tab to make sure it is not overwritten with empty -> false.
+	 *
+	 * @param string|null $input The current content of the filter value.
+	 *
+	 * @return string|null The unmodified content of the filter value.
+	 */
+	public function add_hidden_settings( $input ) {
+		echo '<input type="hidden" name="wpseo_titles[disable-attachment]" value="on">';
+
+		return $input;
+	}
+
+	/**
 	 * Ensures the settings are set as we recommend them to be.
 	 */
 	public function enforce_settings() {

--- a/src/Yoast_Purge_Control_Yoast_SEO_Settings.php
+++ b/src/Yoast_Purge_Control_Yoast_SEO_Settings.php
@@ -25,16 +25,4 @@ class Yoast_Purge_Control_Yoast_SEO_Settings {
 
 		return $input;
 	}
-
-	/**
-	 * Ensures the settings are set as we recommend them to be.
-	 */
-	public function enforce_settings() {
-		// Disable the attachment pages and redirect them to the attachment itself.
-		WPSEO_Options::set( 'disable-attachment', true );
-
-		// Make sure the Purge messages will never be shown again.
-		WPSEO_Options::set( 'is-media-purge-relevant', false );
-
-	}
 }

--- a/src/Yoast_Purge_Control_Yoast_SEO_Settings.php
+++ b/src/Yoast_Purge_Control_Yoast_SEO_Settings.php
@@ -21,15 +21,6 @@ class Yoast_Purge_Control_Yoast_SEO_Settings {
 	}
 
 	/**
-	 * Ensures the settings are set as we recommend them to be.
-	 *
-	 * @deprecated 1.1.0
-	 */
-	public function enforce_settings() {
-		// Intentionally left empty.
-	}
-
-	/**
 	 * Adds the setting to the media tab to make sure it is not overwritten with empty -> false.
 	 *
 	 * @param string|null $input The current content of the filter value.
@@ -40,5 +31,14 @@ class Yoast_Purge_Control_Yoast_SEO_Settings {
 		echo '<input type="hidden" name="wpseo_titles[disable-attachment]" value="on">';
 
 		return $input;
+	}
+
+	/**
+	 * Ensures the settings are set as we recommend them to be.
+	 *
+	 * @deprecated 1.1.0
+	 */
+	public function enforce_settings() {
+		// Intentionally left empty.
 	}
 }

--- a/src/Yoast_Purge_Control_Yoast_SEO_Settings.php
+++ b/src/Yoast_Purge_Control_Yoast_SEO_Settings.php
@@ -21,6 +21,15 @@ class Yoast_Purge_Control_Yoast_SEO_Settings {
 	}
 
 	/**
+	 * Ensures the settings are set as we recommend them to be.
+	 *
+	 * @deprecated 1.1.0
+	 */
+	public function enforce_settings() {
+		// Intentionally left empty.
+	}
+
+	/**
 	 * Adds the setting to the media tab to make sure it is not overwritten with empty -> false.
 	 *
 	 * @param string|null $input The current content of the filter value.

--- a/src/Yoast_Purge_Options.php
+++ b/src/Yoast_Purge_Options.php
@@ -44,7 +44,7 @@ final class Yoast_Purge_Options {
 	 * @return void
 	 */
 	public function set_version( $version ) {
-		update_option( self::KEY_VERSION, $version );
+		update_option( self::KEY_VERSION, $version, true );
 	}
 
 	/**
@@ -64,7 +64,7 @@ final class Yoast_Purge_Options {
 	 * @return bool Whether or not the value was updated.
 	 */
 	public function set_activation_date( $value ) {
-		return update_option( self::KEY_ACTIVATION_DATE, $value );
+		return update_option( self::KEY_ACTIVATION_DATE, $value, true );
 	}
 
 	/**
@@ -101,7 +101,7 @@ final class Yoast_Purge_Options {
 	public function set_purge_attachment_pages( $value ) {
 		$value = ( $value === true ) ? 'true' : 'false';
 
-		return update_option( self::KEY_PURGE_ATTACHMENT_PAGES, $value );
+		return update_option( self::KEY_PURGE_ATTACHMENT_PAGES, $value, true );
 	}
 
 	/**

--- a/src/Yoast_Purge_Options.php
+++ b/src/Yoast_Purge_Options.php
@@ -7,6 +7,27 @@ final class Yoast_Purge_Options {
 
 	const KEY_ACTIVATION_DATE = 'yoast-index-purge-activation-date';
 	const KEY_PURGE_ATTACHMENT_PAGES = 'yoast-index-purge-attachment-pages';
+	const KEY_VERSION = 'yoast-index-purge-version';
+
+	/**
+	 * Retrieves the stored version.
+	 *
+	 * @return string The version saved in the database.
+	 */
+	public function get_version() {
+		return get_option( self::KEY_VERSION, null );
+	}
+
+	/**
+	 * Updates the version.
+	 *
+	 * @param string $version The version to set.
+	 *
+	 * @return void
+	 */
+	public function set_version( $version ) {
+		update_option( self::KEY_VERSION, $version );
+	}
 
 	/**
 	 * Returns the activation date of the plugin as a unix timestamp.

--- a/src/Yoast_Purge_Plugin.php
+++ b/src/Yoast_Purge_Plugin.php
@@ -68,14 +68,4 @@ final class Yoast_Purge_Plugin {
 	public function get_integrations() {
 		return $this->integrations;
 	}
-
-	/**
-	 * Executes everything we need on activation.
-	 */
-	public function activate() {
-		$seo_settings = new Yoast_Purge_Control_Yoast_SEO_Settings();
-		$seo_settings->enforce_settings();
-
-		$this->options->set_default_options();
-	}
 }

--- a/src/Yoast_Purge_Plugin.php
+++ b/src/Yoast_Purge_Plugin.php
@@ -35,6 +35,7 @@ final class Yoast_Purge_Plugin {
 			$this->integrations = array_merge(
 				$this->integrations,
 				array(
+					new Yoast_Purge_Upgrade( $this->options ),
 					new Yoast_Purge_Attachment_Page_Server(),
 					new Yoast_Purge_Media_Settings_Tab_Content(),
 					new Yoast_Purge_Attachment_Sitemap( $this->options ),

--- a/src/Yoast_Purge_Plugin.php
+++ b/src/Yoast_Purge_Plugin.php
@@ -39,14 +39,15 @@ final class Yoast_Purge_Plugin {
 	 * Adds the integrations that the plugin needs.
 	 */
 	public function add_integrations() {
-		$this->integrations = array();
+		$this->integrations = array(
+			new Yoast_Purge_Upgrade( $this->options ),
+		);
 
 		// Add integrations that handle the purging of the attachment pages.
 		if ( $this->options->is_attachment_page_purging_active() ) {
 			$this->integrations = array_merge(
 				$this->integrations,
 				array(
-					new Yoast_Purge_Upgrade( $this->options ),
 					new Yoast_Purge_Attachment_Page_Server(),
 					new Yoast_Purge_Media_Settings_Tab_Content(),
 					new Yoast_Purge_Attachment_Sitemap( $this->options ),

--- a/src/Yoast_Purge_Plugin.php
+++ b/src/Yoast_Purge_Plugin.php
@@ -36,15 +36,6 @@ final class Yoast_Purge_Plugin {
 	}
 
 	/**
-	 * Executes everything we need on activation.
-	 *
-	 * @deprecated 1.1.0
-	 */
-	public function activate() {
-		// Intentionally left empty.
-	}
-
-	/**
 	 * Adds the integrations that the plugin needs.
 	 */
 	public function add_integrations() {
@@ -88,5 +79,14 @@ final class Yoast_Purge_Plugin {
 	 */
 	public function get_integrations() {
 		return $this->integrations;
+	}
+
+	/**
+	 * Executes everything we need on activation.
+	 *
+	 * @deprecated 1.1.0
+	 */
+	public function activate() {
+		// Intentionally left empty.
 	}
 }

--- a/src/Yoast_Purge_Plugin.php
+++ b/src/Yoast_Purge_Plugin.php
@@ -38,6 +38,7 @@ final class Yoast_Purge_Plugin {
 					new Yoast_Purge_Attachment_Page_Server(),
 					new Yoast_Purge_Media_Settings_Tab_Content(),
 					new Yoast_Purge_Attachment_Sitemap( $this->options ),
+					new Yoast_Purge_Control_Yoast_SEO_Settings()
 				)
 			);
 		}

--- a/src/Yoast_Purge_Plugin.php
+++ b/src/Yoast_Purge_Plugin.php
@@ -36,6 +36,15 @@ final class Yoast_Purge_Plugin {
 	}
 
 	/**
+	 * Executes everything we need on activation.
+	 *
+	 * @deprecated 1.1.0
+	 */
+	public function activate() {
+		// Intentionally left empty.
+	}
+
+	/**
 	 * Adds the integrations that the plugin needs.
 	 */
 	public function add_integrations() {

--- a/src/Yoast_Purge_Upgrade.php
+++ b/src/Yoast_Purge_Upgrade.php
@@ -28,12 +28,12 @@ final class Yoast_Purge_Upgrade {
 	 * Runs upgrades, if applicable.
 	 */
 	private function run() {
+		$this->options->set_default_options();
+
 		$version = $this->options->get_version();
 		if ( $version === YOAST_PURGE_VERSION ) {
 			return;
 		}
-
-		$this->options->set_default_options();
 
 		if ( version_compare( $version, '1.0.0', '<' ) ) {
 			$this->upgrade_100();
@@ -48,6 +48,7 @@ final class Yoast_Purge_Upgrade {
 	 * @return void
 	 */
 	private function finish_up() {
+		// Ensure the current version is set in the database.
 		$this->options->set_version( YOAST_PURGE_VERSION );
 
 		// Flush the sitemap cache, to make sure the changes are picked up.

--- a/src/Yoast_Purge_Upgrade.php
+++ b/src/Yoast_Purge_Upgrade.php
@@ -1,0 +1,62 @@
+<?php
+
+final class Yoast_Purge_Upgrade {
+	/**
+	 * @var Yoast_Purge_Options
+	 */
+	private $options;
+
+	/**
+	 * Yoast_Purge_Upgrade constructor.
+	 *
+	 * @param Yoast_Purge_Options $options
+	 */
+	public function __construct( Yoast_Purge_Options $options ) {
+		$this->options = $options;
+	}
+
+	/**
+	 * Registers WordPress hooks and filters.
+	 *
+	 * @return void
+	 */
+	public function register_hooks() {
+		$this->run();
+	}
+
+	/**
+	 * Runs upgrades, if applicable.
+	 */
+	private function run() {
+		$version = $this->options->get_version();
+		if ( $version === YOAST_PURGE_VERSION ) {
+			return;
+		}
+
+		if ( version_compare( $version, '1.0.0', '<' ) ) {
+			$this->upgrade_101();
+		}
+
+		$this->finish_up();
+	}
+
+	/**
+	 * Completes the upgrade routine.
+	 *
+	 * @return void
+	 */
+	private function finish_up() {
+		$this->options->set_version( YOAST_PURGE_VERSION );
+	}
+
+	/**
+	 * Upgrades to version 1.0.1
+	 */
+	private function upgrade_101() {
+		// Disable the attachment pages and redirect them to the attachment itself.
+		WPSEO_Options::set( 'disable-attachment', true );
+
+		// Make sure the Purge messages will never be shown again.
+		WPSEO_Options::set( 'is-media-purge-relevant', false );
+	}
+}

--- a/src/Yoast_Purge_Upgrade.php
+++ b/src/Yoast_Purge_Upgrade.php
@@ -28,6 +28,7 @@ final class Yoast_Purge_Upgrade {
 	 * Runs upgrades, if applicable.
 	 */
 	private function run() {
+		// Always make sure the defaults are set - these are autoloaded.
 		$this->options->set_default_options();
 
 		$version = $this->options->get_version();

--- a/src/Yoast_Purge_Upgrade.php
+++ b/src/Yoast_Purge_Upgrade.php
@@ -26,6 +26,8 @@ final class Yoast_Purge_Upgrade {
 
 	/**
 	 * Runs upgrades, if applicable.
+	 *
+	 * @return void
 	 */
 	private function run() {
 		// Always make sure the defaults are set - these are autoloaded.
@@ -58,6 +60,8 @@ final class Yoast_Purge_Upgrade {
 
 	/**
 	 * Upgrades to version 1.0.0
+	 *
+	 * @return void
 	 */
 	private function upgrade_100() {
 		// Disable the attachment pages and redirect them to the attachment itself.

--- a/src/Yoast_Purge_Upgrade.php
+++ b/src/Yoast_Purge_Upgrade.php
@@ -33,8 +33,10 @@ final class Yoast_Purge_Upgrade {
 			return;
 		}
 
+		$this->options->set_default_options();
+
 		if ( version_compare( $version, '1.0.0', '<' ) ) {
-			$this->upgrade_101();
+			$this->upgrade_100();
 		}
 
 		$this->finish_up();
@@ -50,9 +52,9 @@ final class Yoast_Purge_Upgrade {
 	}
 
 	/**
-	 * Upgrades to version 1.0.1
+	 * Upgrades to version 1.0.0
 	 */
-	private function upgrade_101() {
+	private function upgrade_100() {
 		// Disable the attachment pages and redirect them to the attachment itself.
 		WPSEO_Options::set( 'disable-attachment', true );
 

--- a/src/Yoast_Purge_Upgrade.php
+++ b/src/Yoast_Purge_Upgrade.php
@@ -49,6 +49,9 @@ final class Yoast_Purge_Upgrade {
 	 */
 	private function finish_up() {
 		$this->options->set_version( YOAST_PURGE_VERSION );
+
+		// Flush the sitemap cache, to make sure the changes are picked up.
+		WPSEO_Sitemaps_Cache::clear();
 	}
 
 	/**

--- a/yoast-seo-search-index-purge.php
+++ b/yoast-seo-search-index-purge.php
@@ -40,6 +40,7 @@ if ( ! function_exists( 'add_filter' ) ) {
 
 define( 'YOAST_PURGE_PLUGIN_DIR', dirname( __FILE__ ) );
 define( 'YOAST_PURGE_FILE', __FILE__ );
+define( 'YOAST_PURGE_VERSION', '1.0.0' );
 
 require_once YOAST_PURGE_PLUGIN_DIR . '/src/Yoast_Purge_Attachment_Page_Server.php';
 require_once YOAST_PURGE_PLUGIN_DIR . '/src/Yoast_Purge_Attachment_Sitemap.php';
@@ -47,11 +48,12 @@ require_once YOAST_PURGE_PLUGIN_DIR . '/src/Yoast_Purge_Control_Yoast_SEO_Settin
 require_once YOAST_PURGE_PLUGIN_DIR . '/src/Yoast_Purge_Media_Settings_Tab_Content.php';
 require_once YOAST_PURGE_PLUGIN_DIR . '/src/Yoast_Purge_Options.php';
 require_once YOAST_PURGE_PLUGIN_DIR . '/src/Yoast_Purge_Plugin.php';
+require_once YOAST_PURGE_PLUGIN_DIR . '/src/Yoast_Purge_Upgrade.php';
 require_once YOAST_PURGE_PLUGIN_DIR . '/src/Yoast_Purge_Require_Yoast_SEO_Version.php';
 
 global $yoast_purge_plugin;
 $yoast_purge_plugin = new Yoast_Purge_Plugin();
 $yoast_purge_plugin->add_integrations();
-add_action( 'plugins_loaded', array( $yoast_purge_plugin, 'register_hooks' ) );
+add_action( 'plugins_loaded', array( $yoast_purge_plugin, 'register_hooks' ), 20 );
 
 register_activation_hook( YOAST_PURGE_FILE, array( $yoast_purge_plugin, 'activate' ) );

--- a/yoast-seo-search-index-purge.php
+++ b/yoast-seo-search-index-purge.php
@@ -54,6 +54,5 @@ require_once YOAST_PURGE_PLUGIN_DIR . '/src/Yoast_Purge_Require_Yoast_SEO_Versio
 global $yoast_purge_plugin;
 $yoast_purge_plugin = new Yoast_Purge_Plugin();
 $yoast_purge_plugin->add_integrations();
-add_action( 'plugins_loaded', array( $yoast_purge_plugin, 'register_hooks' ), 20 );
 
-register_activation_hook( YOAST_PURGE_FILE, array( $yoast_purge_plugin, 'activate' ) );
+add_action( 'plugins_loaded', array( $yoast_purge_plugin, 'register_hooks' ), 20 );


### PR DESCRIPTION
This will keep the setting `disable-attachment` set to `true` - which is the desired value of this setting.

When the "Save" button is used on the Media tab, the form field is not present and it will be set to `empty` which results in `false`, which is not what we want!

* Removed the `activation` hooks in favor of the Upgrade routine.
* Changed the `plugins_loaded` priority to 20, to make sure Yoast SEO has initialized the settings API

Fixes #35 