### PR TITLE
Composer: flesh out the `composer.json` file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 /vendor/
 .DS_Store
 .idea/
+composer.lock

--- a/composer.json
+++ b/composer.json
@@ -3,11 +3,27 @@
     "type": "wordpress-plugin",
     "description": "Search Index Purge plugin to combat Search Index problems",
     "license": "GPL-2.0-or-later",
+    "keywords": [
+        "wordpress",
+        "seo"
+    ],
+    "homepage": "https://github.com/Yoast/search-index-purge",
     "authors": [
         {
             "name": "Team Yoast",
-            "email": "support@yoast.com"
+            "email": "support@yoast.com",
+            "homepage": "https://yoast.com"
         }
     ],
-    "require": {}
+    "support": {
+        "issues": "https://github.com/Yoast/search-index-purge/issues",
+        "forum" : "https://wordpress.org/support/plugin/search-index-purge",
+        "source": "https://github.com/Yoast/search-index-purge"
+    },
+    "require": {},
+    "require-dev": {
+        "roave/security-advisories": "dev-master"
+    },
+    "minimum-stability": "dev",
+    "prefer-stable": true
 }


### PR DESCRIPTION
* Add security `dev` dependency to prevent unsafe dependencies from being installed.
* Add keywords.
* Add `support` section.

As, at this point, there are no non-dev dependencies and the `dev` dependency this PR adds should be used at `dev-master` anyway, the `composer.lock` file is excluded from being committed at this time.
This can be revisited if/when non-dev dependencies will be added.