### PR TITLE
Travis: various tweaks

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,20 +8,35 @@ branches:
     # Also build tags like 1.1.1 or 1.1 for deployment.
     - /(\d+\.)?(\d+\.)?(\*|\d+)/
 
+php:
+- 7.0
+- 5.6
+- nightly
+
 jobs:
   fast_finish: true
   include:
     - php: 7.2
-      env: PHPLINT=1
-    - php: 5.2
-      env: PHPLINT=1
+      env: COMPVAL=1
+    - php: 5.3
+      env: COMPVAL=1
       # As 'trusty' is not supporting PHP 5.2/5.3 anymore, we need to force using 'precise'.
       dist: precise
+    - php: 5.2
+      # As 'trusty' is not supporting PHP 5.2/5.3 anymore, we need to force using 'precise'.
+      dist: precise
+
+  allow_failures:
+    # Allow failures for unstable builds.
+    - php: nightly
 
 cache:
   directories:
     - vendor
-    - $HOME/.composer/cache
+    # Cache directory for older Composer versions.
+    - $HOME/.composer/cache/files
+    # Cache directory for more recent Composer versions.
+    - $HOME/.cache/composer/files
 
 before_install:
 #- if [[ "$COVERAGE" != "1" ]]; then phpenv config-rm xdebug.ini || echo 'No xdebug config.'; fi
@@ -53,12 +68,9 @@ before_script:
 
 script:
 # PHP Linting
-- |
-  if [[ "$PHPLINT" == "1" ]]; then
-    travis_fold start "PHP.check" && travis_time_start
-    find -L . -path ./vendor -prune -o -path ./node_modules -prune -o -name '*.php' -print0 | xargs -0 -n 1 -P 4 php -l
-    travis_time_finish && travis_fold end "PHP.check"
-  fi
+- travis_fold start "PHP.check" && travis_time_start
+- find -L . -path ./vendor -prune -o -path ./node_modules -prune -o -name '*.php' -print0 | xargs -0 -n 1 -P 4 php -l
+- travis_time_finish && travis_fold end "PHP.check"
 # PHP CS
 #- |
 #  if [[ "$PHPCS" == "1" ]]; then
@@ -68,4 +80,4 @@ script:
 #  fi
 # Validate the composer.json file.
 # @link https://getcomposer.org/doc/03-cli.md#validate
-- if [[ $TRAVIS_PHP_VERSION == "5.3" || $TRAVIS_PHP_VERSION == "7.2" ]]; then composer validate --no-check-all; fi
+- if [[ $COMPVAL== "1" ]]; then composer validate --no-check-all; fi


### PR DESCRIPTION
Linting:
* Always run a PHP lint on the files.
* Run linting against highest/lowest of each PHP major and nightly.

Composer:
* Improve Composer caching by caching the correct directories
* Add an environment variable to determine whether `composer validate` should run.
* Add a PHP 5.3 build so the Composer file will be validated against the lowest possible PHP version.