### PR TITLE
Exclude newly added attachments from the 410-sitemap

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,9 +18,9 @@ jobs:
   fast_finish: true
   include:
     - php: 7.2
-      env: COMPVAL=1
+      env: VALIDATE_COMPOSER=1
     - php: 5.3
-      env: COMPVAL=1
+      env: VALIDATE_COMPOSER=1
       # As 'trusty' is not supporting PHP 5.2/5.3 anymore, we need to force using 'precise'.
       dist: precise
     - php: 5.2
@@ -81,4 +81,4 @@ script:
 #  fi
 # Validate the composer.json file.
 # @link https://getcomposer.org/doc/03-cli.md#validate
-- if [[ $COMPVAL== "1" ]]; then composer validate --no-check-all; fi
+- if [[ $VALIDATE_COMPOSER == "1" ]]; then composer validate --no-check-all; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -69,9 +69,8 @@ before_script:
 
 script:
 # PHP Linting
-- travis_fold start "PHP.check" && travis_time_start
 - find -L . -path ./vendor -prune -o -path ./node_modules -prune -o -name '*.php' -print0 | xargs -0 -n 1 -P 4 php -l
-- travis_time_finish && travis_fold end "PHP.check"
+
 # PHP CS
 #- |
 #  if [[ "$PHPCS" == "1" ]]; then

--- a/src/Yoast_Purge_Attachment_Sitemap.php
+++ b/src/Yoast_Purge_Attachment_Sitemap.php
@@ -4,7 +4,7 @@
 final class Yoast_Purge_Attachment_Sitemap {
 
 	/** @var Yoast_Purge_Options */
-	protected $options;
+	private $options;
 
 	/**
 	 * Initializes.
@@ -21,6 +21,69 @@ final class Yoast_Purge_Attachment_Sitemap {
 	public function register_hooks() {
 		add_filter( 'wpseo_sitemaps_providers', array( $this, 'add_provider' ) );
 		add_filter( 'wpseo_build_sitemap_post_type', array( $this, 'change_type' ) );
+
+		// Exclude attachments that were added after activation.
+		add_filter( 'wpseo_typecount_where', array( $this, 'typecount_where_filter' ), 10, 2 );
+		add_filter( 'wpseo_exclude_from_sitemap_by_post_ids', array( $this, 'exclude_newly_added_attachments' ), 10, 2 );
+	}
+
+	/**
+	 * Modifies the sitemap count for attachments added after activating the plugin.
+	 *
+	 * @param string $where     SQL part, defaults to empty string.
+	 * @param string $post_type Post type name.
+	 *
+	 * @return string Adjusted WHERE query part.
+	 */
+	public function typecount_where_filter( $where, $post_type ) {
+		global $wpdb;
+
+		// Only hook into attachment sitemaps.
+		if ( $post_type !== 'attachment' ) {
+			return $where;
+		}
+
+		// Only count items added before activating.
+		$where .= $wpdb->prepare(
+			" AND {$wpdb->posts}.post_date <= %s",
+			date( 'Y-m-d H:i:s', $this->options->get_activation_date() )
+		);
+
+		return $where;
+	}
+
+	/**
+	 * Excludes attachments from the sitemap that were added after activating.
+	 *
+	 * @param array $excluded List of excluded post ids.
+	 *
+	 * @return array Modified list of excluded post ids.
+	 */
+	public function exclude_newly_added_attachments( $excluded ) {
+		// Add newly added attachments to the list.
+		$timestamp = $this->options->get_activation_date();
+
+		$wp_query = new WP_Query(
+			array(
+				'post_type' => 'attachment',
+				'post_status' => 'any',
+				'posts_per_page' => '100000',
+				'date_query'     => array(
+					'after' => date( 'Y-m-d H:i:s', $timestamp ),
+				),
+				'fields' => 'ids'
+			)
+		);
+
+		if ( empty( $wp_query->posts ) ) {
+			return $excluded;
+		}
+
+		// Make sure the variable is an array.
+		$excluded = (array) $excluded;
+
+		// Combine the two into a complete list.
+		return array_unique( array_merge( $excluded, $wp_query->posts ) );
 	}
 
 	/**

--- a/src/Yoast_Purge_Attachment_Sitemap_Provider.php
+++ b/src/Yoast_Purge_Attachment_Sitemap_Provider.php
@@ -13,6 +13,64 @@ final class Yoast_Purge_Attachment_Sitemap_Provider extends WPSEO_Post_Type_Site
 	 */
 	public function __construct( Yoast_Purge_Options $options ) {
 		$this->options = $options;
+
+		add_filter( 'wpseo_typecount_where', array( $this, 'typecount_where_filter' ), 10, 2 );
+		add_filter( 'wpseo_exclude_from_sitemap_by_post_ids', array( $this, 'exclude_newly_added_attachments' ), 10, 2 );
+	}
+
+	/**
+	 * Modifies the sitemap count for attachments added after activating the plugin.
+	 *
+	 * @param string $where     SQL part, defaults to empty string.
+	 * @param string $post_type Post type name.
+	 *
+	 * @return string Adjusted WHERE query part.
+	 */
+	public function typecount_where_filter( $where, $post_type ) {
+		global $wpdb;
+
+		// Only hook into attachment sitemaps.
+		if ( $post_type !== 'attachment' ) {
+			return $where;
+		}
+
+		// Only count items added before activating.
+		$where .= $wpdb->prepare(
+			" AND {$wpdb->posts}.post_date <= %s",
+			date( 'Y-m-d H:i:s', $this->options->get_activation_date() )
+		);
+
+		return $where;
+	}
+
+	/**
+	 * Excludes attachments from the sitemap that were added after activating.
+	 *
+	 * @param array $excluded List of excluded post ids.
+	 *
+	 * @return array Modified list of excluded post ids.
+	 */
+	public function exclude_newly_added_attachments( $excluded ) {
+		// Add newly added attachments to the list.
+		$timestamp = $this->options->get_activation_date();
+
+		$wp_query = new WP_Query(
+			array(
+				'post_type' => 'attachment',
+				'post_status' => 'any',
+				'posts_per_page' => '-1',
+				'date_query'     => array(
+					'after' => date( 'Y-m-d H:i:s', $timestamp ),
+				),
+				'fields' => 'ids'
+			)
+		);
+
+		if ( empty( $wp_query->posts ) ) {
+			return $excluded;
+		}
+
+		return array_unique( array_merge( $excluded, $wp_query->posts ) );
 	}
 
 	/**

--- a/src/Yoast_Purge_Attachment_Sitemap_Provider.php
+++ b/src/Yoast_Purge_Attachment_Sitemap_Provider.php
@@ -4,7 +4,7 @@
 final class Yoast_Purge_Attachment_Sitemap_Provider extends WPSEO_Post_Type_Sitemap_Provider {
 
 	/** @var Yoast_Purge_Options */
-	protected $options;
+	private $options;
 
 	/**
 	 * Initializes.
@@ -13,64 +13,6 @@ final class Yoast_Purge_Attachment_Sitemap_Provider extends WPSEO_Post_Type_Site
 	 */
 	public function __construct( Yoast_Purge_Options $options ) {
 		$this->options = $options;
-
-		add_filter( 'wpseo_typecount_where', array( $this, 'typecount_where_filter' ), 10, 2 );
-		add_filter( 'wpseo_exclude_from_sitemap_by_post_ids', array( $this, 'exclude_newly_added_attachments' ), 10, 2 );
-	}
-
-	/**
-	 * Modifies the sitemap count for attachments added after activating the plugin.
-	 *
-	 * @param string $where     SQL part, defaults to empty string.
-	 * @param string $post_type Post type name.
-	 *
-	 * @return string Adjusted WHERE query part.
-	 */
-	public function typecount_where_filter( $where, $post_type ) {
-		global $wpdb;
-
-		// Only hook into attachment sitemaps.
-		if ( $post_type !== 'attachment' ) {
-			return $where;
-		}
-
-		// Only count items added before activating.
-		$where .= $wpdb->prepare(
-			" AND {$wpdb->posts}.post_date <= %s",
-			date( 'Y-m-d H:i:s', $this->options->get_activation_date() )
-		);
-
-		return $where;
-	}
-
-	/**
-	 * Excludes attachments from the sitemap that were added after activating.
-	 *
-	 * @param array $excluded List of excluded post ids.
-	 *
-	 * @return array Modified list of excluded post ids.
-	 */
-	public function exclude_newly_added_attachments( $excluded ) {
-		// Add newly added attachments to the list.
-		$timestamp = $this->options->get_activation_date();
-
-		$wp_query = new WP_Query(
-			array(
-				'post_type' => 'attachment',
-				'post_status' => 'any',
-				'posts_per_page' => '-1',
-				'date_query'     => array(
-					'after' => date( 'Y-m-d H:i:s', $timestamp ),
-				),
-				'fields' => 'ids'
-			)
-		);
-
-		if ( empty( $wp_query->posts ) ) {
-			return $excluded;
-		}
-
-		return array_unique( array_merge( $excluded, $wp_query->posts ) );
 	}
 
 	/**


### PR DESCRIPTION
Excludes attachments that were added after activating the plugin.

Fixes #48