### PR TITLE
Build: Add phpcs ruleset and travis check

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -7,7 +7,11 @@
 #
 .gitattributes export-ignore
 .gitignore export-ignore
+.phpcs.xml export-ignore
+.phpcs.xml.dist export-ignore
 .travis.yml export-ignore
+phpcs.xml export-ignore
+phpcs.xml.dist export-ignore
 
 #
 # Auto detect text files and perform LF normalization

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@
 .DS_Store
 .idea/
 composer.lock
+.phpcs.xml
+phpcs.xml

--- a/.phpcs.xml.dist
+++ b/.phpcs.xml.dist
@@ -72,4 +72,17 @@
 		</properties>
 	</rule>
 
+
+	<!--
+	#############################################################################
+	SELECTIVE EXCLUSIONS
+	Exclude specific files for specific sniffs and/or exclude sub-groups in sniffs.
+	#############################################################################
+	-->
+
+	<!-- Not an issue unless and until this plugin would apply for acceptance on the WP VIP platform. -->
+	<rule ref="WordPress.VIP.PostsPerPage.posts_per_page_posts_per_page">
+		<exclude-pattern>*/src/attachment-sitemap\.php$</exclude-pattern>
+	</rule>
+
 </ruleset>

--- a/.phpcs.xml.dist
+++ b/.phpcs.xml.dist
@@ -1,0 +1,75 @@
+<?xml version="1.0"?>
+<ruleset name="Yoast Search Index Purge">
+	<description>Yoast Search Index Purge rules for PHP_CodeSniffer</description>
+
+	<!--
+	#############################################################################
+	COMMAND LINE ARGUMENTS
+	https://github.com/squizlabs/PHP_CodeSniffer/wiki/Annotated-ruleset.xml
+	#############################################################################
+	-->
+
+	<file>.</file>
+
+	<exclude-pattern>vendor/*</exclude-pattern>
+
+	<!-- Only check PHP files. -->
+	<arg name="extensions" value="php"/>
+
+	<!-- Show progress, show the error codes for each message (source). -->
+	<arg value="ps"/>
+
+	<!-- Strip the filepaths down to the relevant bit. -->
+	<arg name="basepath" value="./"/>
+
+	<!-- Check up to 8 files simultanously. -->
+	<arg name="parallel" value="8"/>
+
+
+	<!--
+	#############################################################################
+	USE THE YoastCS RULESET
+	#############################################################################
+	-->
+
+	<rule ref="Yoast"/>
+
+
+	<!--
+	#############################################################################
+	SNIFF SPECIFIC CONFIGURATION
+	#############################################################################
+	-->
+
+	<!-- Set the minimum supported WP version. This is used by several sniffs. -->
+	<config name="minimum_supported_wp_version" value="4.8"/>
+
+	<!-- Verify that all gettext calls use the correct text domain. -->
+	<rule ref="WordPress.WP.I18n">
+		<properties>
+			<property name="text_domain" type="array">
+				<element value="yoast-search-index-purge"/>
+			</property>
+		</properties>
+	</rule>
+
+	<rule ref="Yoast.Files.FileName">
+		<properties>
+			<!-- Remove the following prefixes from the names of object structures. -->
+			<property name="prefixes" type="array">
+				<element value="Yoast_Purge"/>
+			</property>
+		</properties>
+	</rule>
+
+	<!-- Verify that everything in the global namespace is prefixed with a plugin specific prefix. -->
+	<rule ref="WordPress.NamingConventions.PrefixAllGlobals">
+		<properties>
+			<!-- Provide the prefixes to look for. -->
+			<property name="prefixes" type="array">
+				<element value="yoast"/>
+			</property>
+		</properties>
+	</rule>
+
+</ruleset>

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,7 @@ jobs:
   fast_finish: true
   include:
     - php: 7.2
-      env: VALIDATE_COMPOSER=1
+      env: VALIDATE_COMPOSER=1 PHPCS=1
     - php: 5.3
       env: VALIDATE_COMPOSER=1
       # As 'trusty' is not supporting PHP 5.2/5.3 anymore, we need to force using 'precise'.
@@ -72,12 +72,12 @@ script:
 - find -L . -path ./vendor -prune -o -path ./node_modules -prune -o -name '*.php' -print0 | xargs -0 -n 1 -P 4 php -l
 
 # PHP CS
-#- |
-#  if [[ "$PHPCS" == "1" ]]; then
-#    travis_fold start "PHP.code-style" && travis_time_start
-#    vendor/bin/phpcs -q --runtime-set ignore_warnings_on_exit 1
-#    travis_time_finish && travis_fold end "PHP.code-style"
-#  fi
+- |
+  if [[ "$PHPCS" == "1" ]]; then
+    travis_fold start "PHP.code-style" && travis_time_start
+    vendor/bin/phpcs -q --runtime-set ignore_warnings_on_exit 1
+    travis_time_finish && travis_fold end "PHP.code-style"
+  fi
 # Validate the composer.json file.
 # @link https://getcomposer.org/doc/03-cli.md#validate
 - if [[ $VALIDATE_COMPOSER == "1" ]]; then composer validate --no-check-all; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -75,7 +75,7 @@ script:
 - |
   if [[ "$PHPCS" == "1" ]]; then
     travis_fold start "PHP.code-style" && travis_time_start
-    vendor/bin/phpcs -q --runtime-set ignore_warnings_on_exit 1
+    vendor/bin/phpcs -q
     travis_time_finish && travis_fold end "PHP.code-style"
   fi
 # Validate the composer.json file.

--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,9 @@
     },
     "require": {},
     "require-dev": {
-        "roave/security-advisories": "dev-master"
+        "roave/security-advisories": "dev-master",
+        "yoast/yoastcs": "~0.5.0",
+        "dealerdirect/phpcodesniffer-composer-installer": "^0.4.3"
     },
     "minimum-stability": "dev",
     "prefer-stable": true

--- a/src/attachment-page-server.php
+++ b/src/attachment-page-server.php
@@ -36,6 +36,7 @@ final class Yoast_Purge_Attachment_Page_Server {
 	 */
 	public function render_file( $filepath, $mime_type ) {
 		// Open the attachment in a binary mode.
+		// phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_read_fopen -- Local file, optimized solution.
 		$file = fopen( $filepath, 'rb' );
 
 		// Send the right headers.

--- a/src/require-yoast-seo-version.php
+++ b/src/require-yoast-seo-version.php
@@ -67,10 +67,12 @@ final class Yoast_Purge_Require_Yoast_SEO_Version {
 	 * Displays an admin error.
 	 *
 	 * @param string $message Notice to display.
+	 *                        The notice should be pre-escaped for output.
 	 *
 	 * @return void
 	 */
 	private function display_admin_error( $message ) {
+		// phpcs:ignore WordPress.XSS.EscapeOutput -- Pre-escaped message expected.
 		echo '<div class="error"><p>' . $message . '</p></div>';
 	}
 


### PR DESCRIPTION
Please see the individual commits for more info.

@moorscode Currently `warning`s will not break the build. There is only one (1) warning left now and I'm not sure whether or not this issue should be actioned.

```
FILE: src\attachment-page-server.php
------------------------------------------------------------------------------------------
FOUND 0 ERRORS AND 1 WARNING AFFECTING 1 LINE
------------------------------------------------------------------------------------------
 39 | WARNING | File operations should use WP_Filesystem methods instead of direct PHP
    |         | filesystem calls. Found: fopen()
    |         | (WordPress.WP.AlternativeFunctions.file_system_read_fopen)
------------------------------------------------------------------------------------------
```

I could open a `technical-debt` issue for this and temporarily ignore the `warning` òr if it isn't really an issue, I could add an inline whitelist comment.

If either of the above two actions is taken, we can let the build fail on `warning`s as well.


Other notes:
* I have not added a `composer.lock` file as all dependencies are `dev` dependencies, so as long as the version restrictions are set properly (which they should be), this should be fine.
