### PR TITLE
PHPCS: Update to use YoastCS 1.0 / WPCS ~1.0~ 1.1.0

### DIFF
--- a/.phpcs.xml.dist
+++ b/.phpcs.xml.dist
@@ -67,7 +67,7 @@
 		<properties>
 			<!-- Provide the prefixes to look for. -->
 			<property name="prefixes" type="array">
-				<element value="yoast"/>
+				<element value="yoast_purge"/>
 			</property>
 		</properties>
 	</rule>

--- a/.phpcs.xml.dist
+++ b/.phpcs.xml.dist
@@ -72,17 +72,4 @@
 		</properties>
 	</rule>
 
-
-	<!--
-	#############################################################################
-	SELECTIVE EXCLUSIONS
-	Exclude specific files for specific sniffs and/or exclude sub-groups in sniffs.
-	#############################################################################
-	-->
-
-	<!-- Not an issue unless and until this plugin would apply for acceptance on the WP VIP platform. -->
-	<rule ref="WordPress.VIP.PostsPerPage.posts_per_page_posts_per_page">
-		<exclude-pattern>*/src/attachment-sitemap\.php$</exclude-pattern>
-	</rule>
-
 </ruleset>

--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,7 @@
     "require": {},
     "require-dev": {
         "roave/security-advisories": "dev-master",
-        "yoast/yoastcs": "~0.5.0",
+        "yoast/yoastcs": "^1.0.0",
         "dealerdirect/phpcodesniffer-composer-installer": "^0.4.3"
     },
     "minimum-stability": "dev",

--- a/src/attachment-sitemap.php
+++ b/src/attachment-sitemap.php
@@ -80,7 +80,7 @@ final class Yoast_Purge_Attachment_Sitemap {
 			array(
 				'post_type'      => 'attachment',
 				'post_status'    => 'any',
-				'posts_per_page' => '100000',
+				'posts_per_page' => '100000', // phpcs:ignore WordPress.WP.PostsPerPage -- This is not for display.
 				'date_query'     => array(
 					'after' => date( 'Y-m-d H:i:s', $timestamp ),
 				),

--- a/src/control-yoast-seo-settings.php
+++ b/src/control-yoast-seo-settings.php
@@ -11,6 +11,7 @@
  * This class ensures the Yoast SEO Settings are being set as needed.
  */
 class Yoast_Purge_Control_Yoast_SEO_Settings {
+
 	/**
 	 * Adds WordPress hooks and filters.
 	 *

--- a/src/media-settings-tab-content.php
+++ b/src/media-settings-tab-content.php
@@ -11,6 +11,7 @@
  * This class will override the Media content tab content.
  */
 class Yoast_Purge_Media_Settings_Tab_Content {
+
 	/**
 	 * Registers the WordPress hooks and filters.
 	 */

--- a/src/require-yoast-seo-version.php
+++ b/src/require-yoast-seo-version.php
@@ -44,14 +44,13 @@ final class Yoast_Purge_Require_Yoast_SEO_Version {
 		}
 
 		if ( ! $this->has_required_version() ) {
-			$this->display_admin_error( sprintf(
-				/* translators: %1$s expands to Yoast SEO. */
-				esc_html__(
-					'Please upgrade the %1$s plugin to the latest version to allow the Yoast SEO: Search Index Purge plugin to work.',
-					'yoast-search-index-purge'
-				),
-				'Yoast SEO'
-			) );
+			/* translators: %1$s expands to Yoast SEO. */
+			$upgrade_msg = esc_html__(
+				'Please upgrade the %1$s plugin to the latest version to allow the Yoast SEO: Search Index Purge plugin to work.',
+				'yoast-search-index-purge'
+			);
+
+			$this->display_admin_error( sprintf( $upgrade_msg, 'Yoast SEO' ) );
 		}
 	}
 

--- a/src/require-yoast-seo-version.php
+++ b/src/require-yoast-seo-version.php
@@ -72,7 +72,7 @@ final class Yoast_Purge_Require_Yoast_SEO_Version {
 	 * @return void
 	 */
 	private function display_admin_error( $message ) {
-		// phpcs:ignore WordPress.XSS.EscapeOutput -- Pre-escaped message expected.
+		// phpcs:ignore WordPress.Security.EscapeOutput -- Pre-escaped message expected.
 		echo '<div class="error"><p>' . $message . '</p></div>';
 	}
 

--- a/src/require-yoast-seo-version.php
+++ b/src/require-yoast-seo-version.php
@@ -11,6 +11,7 @@
  * The class to check for environment requirements.
  */
 final class Yoast_Purge_Require_Yoast_SEO_Version {
+
 	/**
 	 * Registers hooks to WordPress.
 	 */


### PR DESCRIPTION
### Composer: require YoastCS 1.0.0

### PHPCS: update ruleset and annotations for YoastCS/WPCS 1.0.0

* The `VIP` sniffs have been deprecated in WPCS 1.0.0 and are no longer included in the YoastCS ruleset.
* The `EscapeOutput` sniff has been moved to the `Security` category in WPCS 1.0.0.
* A new `WP.PostsPerPage` sniff has been added - based on the old VIP sniff -. As this sniff _should_ be complied with normally, but, for good reason, this plugin doesn't (one time only changes made in the DB, DB query not used for display), the previous ruleset `exclude` has been changed to an inline `ignore` annotation.

### PHPCS: make the prefix used more specific

### CS: minor whitespace fixes to comply with YoastCS 1.0.0 