### PR TITLE
Update for YoastCS 1.1.0 / WPCS ^1.2.0 / PHPCompatibility ^9.0.0

### DIFF
--- a/.phpcs.xml.dist
+++ b/.phpcs.xml.dist
@@ -1,5 +1,8 @@
 <?xml version="1.0"?>
-<ruleset name="Yoast Search Index Purge">
+<ruleset xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	name="Yoast Search Index Purge"
+	xsi:noNamespaceSchemaLocation="./vendor/squizlabs/php_codesniffer/phpcs.xsd">
+
 	<description>Yoast Search Index Purge rules for PHP_CodeSniffer</description>
 
 	<!--
@@ -32,7 +35,11 @@
 	#############################################################################
 	-->
 
-	<rule ref="Yoast"/>
+	<rule ref="Yoast">
+		<!-- This plugin currently does not have unit tests, so using PHPUnit
+			 ignore annotations is not (yet) necessary. -->
+		<exclude name="Yoast.Commenting.CodeCoverageIgnoreDeprecated"/>
+	</rule>
 
 
 	<!--

--- a/composer.json
+++ b/composer.json
@@ -20,11 +20,9 @@
         "forum" : "https://wordpress.org/support/plugin/search-index-purge",
         "source": "https://github.com/Yoast/search-index-purge"
     },
-    "require": {},
     "require-dev": {
         "roave/security-advisories": "dev-master",
-        "yoast/yoastcs": "^1.0.0",
-        "dealerdirect/phpcodesniffer-composer-installer": "^0.4.3"
+        "yoast/yoastcs": "^1.1.0"
     },
     "minimum-stability": "dev",
     "prefer-stable": true

--- a/src/control-yoast-seo-settings.php
+++ b/src/control-yoast-seo-settings.php
@@ -34,6 +34,8 @@ class Yoast_Purge_Control_Yoast_SEO_Settings {
 		return $input;
 	}
 
+	/* ********************* DEPRECATED METHODS ********************* */
+
 	/**
 	 * Ensures the settings are set as we recommend them to be.
 	 *

--- a/src/plugin.php
+++ b/src/plugin.php
@@ -87,6 +87,8 @@ final class Yoast_Purge_Plugin {
 		return $this->integrations;
 	}
 
+	/* ********************* DEPRECATED METHODS ********************* */
+
 	/**
 	 * Executes everything we need on activation.
 	 *


### PR DESCRIPTION
### Composer: require YoastCS 1.1.0

Includes removing the DealerDirect Composer PHPCS plugin which now comes automatically with YoastCS.

### PHPCS: update ruleset for YoastCS 1.1.0

* Ignore the new `Yoast.Commenting.CodeCoverageIgnoreDeprecated` sniff as this plugin does not have unit tests yet, so no code coverage ignore annotations are needed.
* Add the PHPCS XSD to the custom ruleset which should now be valid as the minimum PHPCS requirement has gone up to PHPCS 3.3.2.

### Documentation: add clear deprecation delimiters

This PR basically applies the following rules:
* Deprecated functions/methods should be at the end of the file/class. **Already correct**
* They should be preceded by a `/* *** DEPRECATED METHODS *** */` delimiter to clearly indicate the start of the deprecated functions.

N.B.: YoastCS does not (yet) check for this, but there is an open issue to start checking.