### PR TITLE
PHPCS ruleset: update the prefixes array

### DIFF
--- a/.phpcs.xml.dist
+++ b/.phpcs.xml.dist
@@ -75,6 +75,7 @@
 			<!-- Provide the prefixes to look for. -->
 			<property name="prefixes" type="array">
 				<element value="yoast_purge"/>
+				<element value="Yoast\WP\Purge"/>
 			</property>
 		</properties>
 	</rule>


### PR DESCRIPTION
... to cover both the prefix for global structures as well as for namespaced structures based on the agreed prefixes per September 2018.