### PR TITLE
Composer: sync with other config files

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -7,7 +7,7 @@
         "wordpress",
         "seo"
     ],
-    "homepage": "https://github.com/Yoast/search-index-purge",
+    "homepage": "https://wordpress.org/plugins/yoast-seo-search-index-purge/",
     "authors": [
         {
             "name": "Team Yoast",
@@ -17,13 +17,28 @@
     ],
     "support": {
         "issues": "https://github.com/Yoast/search-index-purge/issues",
-        "forum" : "https://wordpress.org/support/plugin/search-index-purge",
+        "forum" : "https://wordpress.org/support/plugin/yoast-seo-search-index-purge",
         "source": "https://github.com/Yoast/search-index-purge"
+    },
+    "require": {
+        "php": ">=5.2"
     },
     "require-dev": {
         "roave/security-advisories": "dev-master",
         "yoast/yoastcs": "^1.1.0"
     },
     "minimum-stability": "dev",
-    "prefer-stable": true
+    "prefer-stable": true,
+    "scripts": {
+        "config-yoastcs" : [
+            "Dealerdirect\\Composer\\Plugin\\Installers\\PHPCodeSniffer\\Plugin::run",
+            "@php ./vendor/squizlabs/php_codesniffer/bin/phpcs --config-set default_standard Yoast"
+        ],
+        "check-cs": [
+            "@php ./vendor/squizlabs/php_codesniffer/bin/phpcs"
+        ],
+        "fix-cs": [
+            "@php ./vendor/squizlabs/php_codesniffer/bin/phpcbf"
+        ]
+    }
 }


### PR DESCRIPTION
I've done a compare between the `composer.json` config files in (nearly) all plugin repos.

This commit adds some additional properties to the config file to improve consistency with the other repos and predictability for devs.

* Adds an explicit minimum PHP version.
* Adds `config-yoastcs`, `check-cs` and `fix-cs` scripts for use by devs.
    Note: the `config-yoastcs` script is not _needed_ as the DealerDirect plugin sorts this out automatically, however for consistency of the scripts between repos, this has been added anyway.
* Fix the links to the plugin homepage and forum.