### PR TITLE
Travis: test builds against PHP 7.4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ branches:
 php:
 - 7.0
 - 5.6
-- nightly
+- "7.4snapshot"
 
 jobs:
   fast_finish: true
@@ -29,7 +29,7 @@ jobs:
 
   allow_failures:
     # Allow failures for unstable builds.
-    - php: nightly
+    - php: "7.4snapshot"
 
 cache:
   directories:


### PR DESCRIPTION
Nightly has become PHP 8.0 since PHP 7.4 has been branched, so to continue to also test against PHP 7.4, it needs to be added separately.

Refs:
* https://twitter.com/nikita_ppv/status/1089839541828112384
* https://twitter.com/nikita_ppv/status/1094897743594770433

As PHP 8.x - current `nightly` - is not expected to be released until December 2020, with PHP 7.4 expected in December 2019, I've elected to replace the build against `nightly` with a build against `7.4snapshot`.

Once PHP 7.4 is released, the "high PHP" build - currently PHP 7.3 - should be replaced with a build against PHP 7.4 (stable) and the "unstable" build - now `7.4snapshot` - should be reverted to `nightly`.