### PR TITLE
QA: use gmdate() instead of date()

### DIFF
--- a/src/attachment-sitemap-provider.php
+++ b/src/attachment-sitemap-provider.php
@@ -63,7 +63,7 @@ final class Yoast_Purge_Attachment_Sitemap_Provider extends WPSEO_Post_Type_Site
 	public function get_url( $post ) {
 		$link = parent::get_url( $post );
 
-		$link['mod'] = date( 'Y-m-d H:i:s', $this->options->get_activation_date() );
+		$link['mod'] = gmdate( 'Y-m-d H:i:s', $this->options->get_activation_date() );
 
 		return $link;
 	}
@@ -107,7 +107,7 @@ final class Yoast_Purge_Attachment_Sitemap_Provider extends WPSEO_Post_Type_Site
 	 * @return array Modified sitemap link index.
 	 */
 	public function set_modification_date( $entry ) {
-		$entry['lastmod'] = date( 'Y-m-d H:i:s', $this->options->get_activation_date() );
+		$entry['lastmod'] = gmdate( 'Y-m-d H:i:s', $this->options->get_activation_date() );
 
 		return $entry;
 	}

--- a/src/attachment-sitemap.php
+++ b/src/attachment-sitemap.php
@@ -59,7 +59,7 @@ final class Yoast_Purge_Attachment_Sitemap {
 		// Only count items added before activating.
 		$where .= $wpdb->prepare(
 			" AND {$wpdb->posts}.post_date <= %s",
-			date( 'Y-m-d H:i:s', $this->options->get_activation_date() )
+			gmdate( 'Y-m-d H:i:s', $this->options->get_activation_date() )
 		);
 
 		return $where;
@@ -82,7 +82,7 @@ final class Yoast_Purge_Attachment_Sitemap {
 				'post_status'    => 'any',
 				'posts_per_page' => '100000', // phpcs:ignore WordPress.WP.PostsPerPage -- This is not for display.
 				'date_query'     => array(
-					'after' => date( 'Y-m-d H:i:s', $timestamp ),
+					'after' => gmdate( 'Y-m-d H:i:s', $timestamp ),
 				),
 				'fields'         => 'ids',
 			)


### PR DESCRIPTION
> WordPress core sets PHP time zone to UTC during boot. However it cannot guarantee that timezone isn't changed by third party code, which is relatively common in the wild.
>
> date() calls rely on current PHP time zone. If time zone is changed from UTC it causes invalid results through the core and extensions code.

Refs:
* https://core.trac.wordpress.org/ticket/46438
* https://github.com/WordPress/WordPress-Coding-Standards/issues/1713

## Testing

Highly recommended!!!