### PR TITLE
Stop explicit support for PHP < 5.6 / WP < 5.2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 language: php
 dist: trusty
-sudo: false
 
 branches:
   only:
@@ -11,25 +10,20 @@ branches:
 
 php:
 - 7.0
-- 5.6
 - "7.4snapshot"
+- "nightly"
 
 jobs:
   fast_finish: true
   include:
     - php: 7.3
       env: VALIDATE_COMPOSER=1 PHPCS=1
-    - php: 5.3
+    - php: 5.6
       env: VALIDATE_COMPOSER=1
-      # As 'trusty' is not supporting PHP 5.2/5.3 anymore, we need to force using 'precise'.
-      dist: precise
-    - php: 5.2
-      # As 'trusty' is not supporting PHP 5.2/5.3 anymore, we need to force using 'precise'.
-      dist: precise
 
   allow_failures:
     # Allow failures for unstable builds.
-    - php: "7.4snapshot"
+    - php: "nightly"
 
 cache:
   directories:
@@ -40,7 +34,7 @@ cache:
     - $HOME/.cache/composer/files
 
 before_install:
-- if [[ "$COVERAGE" != "1" ]]; then phpenv config-rm xdebug.ini || echo 'No xdebug config.'; fi
+- phpenv config-rm xdebug.ini || echo 'No xdebug config.'
 #- openssl aes-256-cbc -K $encrypted_953eef802505_key -iv $encrypted_953eef802505_iv -in github_deploy_key.enc -out github_deploy_key -d
 #- chmod 600 github_deploy_key
 #- eval $(ssh-agent -s)
@@ -73,7 +67,7 @@ script:
 - |
   if [[ "$PHPCS" == "1" ]]; then
     travis_fold start "PHP.code-style" && travis_time_start
-    vendor/bin/phpcs -q
+    composer check-cs -- -q
     travis_time_finish && travis_fold end "PHP.code-style"
   fi
 # Validate the composer.json file.

--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
         "source": "https://github.com/Yoast/search-index-purge"
     },
     "require": {
-        "php": ">=5.2"
+        "php": ">=5.6"
     },
     "require-dev": {
         "roave/security-advisories": "dev-master",


### PR DESCRIPTION
Includes:
* Removing the build against PHP 7.4 from allowed failures.
* Adding (back) a build against PHP `nightly` (PHP 8).

As the Search Index Purge plugin does not contain unit tests, these changes can already be made and made in one go.

Also:
* Travis hasn't supported `sudo` for quite a while now, so removing it.
* Removing a condition referring to a non-existent `$COVERAGE` environment variable.
* Using the composer scripts to run tasks.

Related to https://github.com/Yoast/wordpress-seo/issues/13758