### PR TITLE
PHPCS: Update to YoastCS 2.0.0

### DIFF
--- a/.phpcs.xml.dist
+++ b/.phpcs.xml.dist
@@ -34,6 +34,14 @@
 	-->
 
 	<rule ref="Yoast">
+		<!-- Provide the plugin specific prefixes for all naming related sniffs. -->
+		<properties>
+			<property name="prefixes" type="array">
+				<element value="Yoast\WP\Purge"/>
+				<element value="yoast_purge"/>
+			</property>
+		</properties>
+
 		<!-- This plugin currently does not have unit tests, so using PHPUnit
 			 ignore annotations is not (yet) necessary. -->
 		<exclude name="Yoast.Commenting.CodeCoverageIgnoreDeprecated"/>
@@ -58,19 +66,17 @@
 	<rule ref="Yoast.Files.FileName">
 		<properties>
 			<!-- Remove the following prefixes from the names of object structures. -->
-			<property name="prefixes" type="array">
+			<property name="oo_prefixes" type="array">
 				<element value="Yoast_Purge"/>
 			</property>
 		</properties>
 	</rule>
 
-	<!-- Verify that everything in the global namespace is prefixed with a plugin specific prefix. -->
-	<rule ref="WordPress.NamingConventions.PrefixAllGlobals">
+	<rule ref="Yoast.NamingConventions.NamespaceName">
 		<properties>
-			<!-- Provide the prefixes to look for. -->
-			<property name="prefixes" type="array">
-				<element value="yoast_purge"/>
-				<element value="Yoast\WP\Purge"/>
+			<!-- Treat the "src" directory as the project root for path to namespace translations. -->
+			<property name="src_directory" type="array">
+				<element value="src"/>
 			</property>
 		</properties>
 	</rule>

--- a/.phpcs.xml.dist
+++ b/.phpcs.xml.dist
@@ -41,10 +41,6 @@
 				<element value="yoast_purge"/>
 			</property>
 		</properties>
-
-		<!-- This plugin currently does not have unit tests, so using PHPUnit
-			 ignore annotations is not (yet) necessary. -->
-		<exclude name="Yoast.Commenting.CodeCoverageIgnoreDeprecated"/>
 	</rule>
 
 

--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,7 @@
     },
     "require-dev": {
         "roave/security-advisories": "dev-master",
-        "yoast/yoastcs": "^1.3.0"
+        "yoast/yoastcs": "^2.0.0"
     },
     "minimum-stability": "dev",
     "prefer-stable": true,

--- a/src/attachment-page-server.php
+++ b/src/attachment-page-server.php
@@ -17,14 +17,14 @@ final class Yoast_Purge_Attachment_Page_Server {
 	 *
 	 * @var array
 	 */
-	private $valid_image_types = array( 'image/jpeg', 'image/gif', 'image/png' );
+	private $valid_image_types = [ 'image/jpeg', 'image/gif', 'image/png' ];
 
 	/**
 	 * Registers to WordPress.
 	 */
 	public function register_hooks() {
 		// We need to do this earlier than Yoast SEO redirects the attachment.
-		add_action( 'template_redirect', array( $this, 'serve' ), -10 );
+		add_action( 'template_redirect', [ $this, 'serve' ], -10 );
 		add_action( 'wpseo_attachment_redirect_url', '__return_null' );
 	}
 

--- a/src/attachment-page-server.php
+++ b/src/attachment-page-server.php
@@ -31,7 +31,7 @@ final class Yoast_Purge_Attachment_Page_Server {
 	/**
 	 * Renders a file with a specific mime type to the browser.
 	 *
-	 * @param string $filepath Path to the file to render.
+	 * @param string $filepath  Path to the file to render.
 	 * @param string $mime_type Mime type to render it with.
 	 */
 	public function render_file( $filepath, $mime_type ) {

--- a/src/attachment-sitemap-provider.php
+++ b/src/attachment-sitemap-provider.php
@@ -94,7 +94,7 @@ final class Yoast_Purge_Attachment_Sitemap_Provider extends WPSEO_Post_Type_Site
 	public function get_index_links( $max_entries ) {
 		$index_links = parent::get_index_links( $max_entries );
 
-		$index_links = array_map( array( $this, 'set_modification_date' ), $index_links );
+		$index_links = array_map( [ $this, 'set_modification_date' ], $index_links );
 
 		return $index_links;
 	}

--- a/src/attachment-sitemap.php
+++ b/src/attachment-sitemap.php
@@ -32,12 +32,12 @@ final class Yoast_Purge_Attachment_Sitemap {
 	 * Registers hooks to WordPress.
 	 */
 	public function register_hooks() {
-		add_filter( 'wpseo_sitemaps_providers', array( $this, 'add_provider' ) );
-		add_filter( 'wpseo_build_sitemap_post_type', array( $this, 'change_type' ) );
+		add_filter( 'wpseo_sitemaps_providers', [ $this, 'add_provider' ] );
+		add_filter( 'wpseo_build_sitemap_post_type', [ $this, 'change_type' ] );
 
 		// Exclude attachments that were added after activation.
-		add_filter( 'wpseo_typecount_where', array( $this, 'typecount_where_filter' ), 10, 2 );
-		add_filter( 'wpseo_exclude_from_sitemap_by_post_ids', array( $this, 'exclude_newly_added_attachments' ), 10, 2 );
+		add_filter( 'wpseo_typecount_where', [ $this, 'typecount_where_filter' ], 10, 2 );
+		add_filter( 'wpseo_exclude_from_sitemap_by_post_ids', [ $this, 'exclude_newly_added_attachments' ], 10, 2 );
 	}
 
 	/**
@@ -77,15 +77,15 @@ final class Yoast_Purge_Attachment_Sitemap {
 		$timestamp = $this->options->get_activation_date();
 
 		$wp_query = new WP_Query(
-			array(
+			[
 				'post_type'      => 'attachment',
 				'post_status'    => 'any',
 				'posts_per_page' => '100000', // phpcs:ignore WordPress.WP.PostsPerPage -- This is not for display.
-				'date_query'     => array(
+				'date_query'     => [
 					'after' => gmdate( 'Y-m-d H:i:s', $timestamp ),
-				),
+				],
 				'fields'         => 'ids',
-			)
+			]
 		);
 
 		if ( empty( $wp_query->posts ) ) {

--- a/src/control-yoast-seo-settings.php
+++ b/src/control-yoast-seo-settings.php
@@ -18,7 +18,7 @@ class Yoast_Purge_Control_Yoast_SEO_Settings {
 	 * @return void
 	 */
 	public function register_hooks() {
-		add_filter( 'wpseo_option_tab-metas_media', array( $this, 'add_hidden_settings' ) );
+		add_filter( 'wpseo_option_tab-metas_media', [ $this, 'add_hidden_settings' ] );
 	}
 
 	/**

--- a/src/control-yoast-seo-settings.php
+++ b/src/control-yoast-seo-settings.php
@@ -40,6 +40,7 @@ class Yoast_Purge_Control_Yoast_SEO_Settings {
 	 * Ensures the settings are set as we recommend them to be.
 	 *
 	 * @deprecated 1.1.0
+	 * @codeCoverageIgnore
 	 */
 	public function enforce_settings() {
 		// Intentionally left empty.

--- a/src/media-settings-tab-content.php
+++ b/src/media-settings-tab-content.php
@@ -16,7 +16,7 @@ class Yoast_Purge_Media_Settings_Tab_Content {
 	 * Registers the WordPress hooks and filters.
 	 */
 	public function register_hooks() {
-		add_filter( 'wpseo_option_tab-metas_media', array( $this, 'get_content' ) );
+		add_filter( 'wpseo_option_tab-metas_media', [ $this, 'get_content' ] );
 	}
 
 	/**

--- a/src/plugin.php
+++ b/src/plugin.php
@@ -17,7 +17,7 @@ final class Yoast_Purge_Plugin {
 	 *
 	 * @var array
 	 */
-	private $integrations = array();
+	private $integrations = [];
 
 	/**
 	 * Yoast SEO requirement checker.
@@ -45,20 +45,20 @@ final class Yoast_Purge_Plugin {
 	 * Adds the integrations that the plugin needs.
 	 */
 	public function add_integrations() {
-		$this->integrations = array(
+		$this->integrations = [
 			new Yoast_Purge_Upgrade( $this->options ),
-		);
+		];
 
 		// Add integrations that handle the purging of the attachment pages.
 		if ( $this->options->is_attachment_page_purging_active() ) {
 			$this->integrations = array_merge(
 				$this->integrations,
-				array(
+				[
 					new Yoast_Purge_Attachment_Page_Server(),
 					new Yoast_Purge_Media_Settings_Tab_Content(),
 					new Yoast_Purge_Attachment_Sitemap( $this->options ),
 					new Yoast_Purge_Control_Yoast_SEO_Settings(),
-				)
+				]
 			);
 		}
 	}

--- a/src/plugin.php
+++ b/src/plugin.php
@@ -93,6 +93,7 @@ final class Yoast_Purge_Plugin {
 	 * Executes everything we need on activation.
 	 *
 	 * @deprecated 1.1.0
+	 * @codeCoverageIgnore
 	 */
 	public function activate() {
 		// Intentionally left empty.

--- a/src/require-yoast-seo-version.php
+++ b/src/require-yoast-seo-version.php
@@ -21,7 +21,7 @@ final class Yoast_Purge_Require_Yoast_SEO_Version {
 			$hook = 'network_' . $hook;
 		}
 
-		add_action( $hook, array( $this, 'show_admin_notices' ) );
+		add_action( $hook, [ $this, 'show_admin_notices' ] );
 	}
 
 	/**

--- a/yoast-seo-search-index-purge.php
+++ b/yoast-seo-search-index-purge.php
@@ -55,4 +55,4 @@ global $yoast_purge_plugin;
 $yoast_purge_plugin = new Yoast_Purge_Plugin();
 $yoast_purge_plugin->add_integrations();
 
-add_action( 'plugins_loaded', array( $yoast_purge_plugin, 'register_hooks' ), 20 );
+add_action( 'plugins_loaded', [ $yoast_purge_plugin, 'register_hooks' ], 20 );


### PR DESCRIPTION
### PHPCS: Update to YoastCS 2.0.0

This updates the dependency in `composer.json`, as well as the PHPCS ruleset for YoastCS 2.0.0.

Ref: https://github.com/Yoast/yoastcs/releases/tag/2.0.0

### CS: use short arrays

### CS: minor tweaks

Remove an exclusion from the ruleset and solve this in the code instead.

### CS: minor documentation tweak 