### PR TITLE
Travis: use 7.4 not snapshot

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,13 +10,12 @@ branches:
 
 php:
 - 7.0
-- "7.4snapshot"
 - "nightly"
 
 jobs:
   fast_finish: true
   include:
-    - php: 7.3
+    - php: 7.4
       env: VALIDATE_COMPOSER=1 PHPCS=1
     - php: 5.6
       env: VALIDATE_COMPOSER=1


### PR DESCRIPTION
Since mid December, Travis now has a native PHP 7.4 image available.