### PR TITLE
PHPCS: enable caching between runs

### DIFF
--- a/.cache/.gitkeep
+++ b/.cache/.gitkeep
@@ -1,0 +1,1 @@
+# This directory has to exist to allow cache files to be written to it.

--- a/.gitattributes
+++ b/.gitattributes
@@ -12,6 +12,7 @@
 .travis.yml export-ignore
 phpcs.xml export-ignore
 phpcs.xml.dist export-ignore
+/.cache export-ignore
 
 #
 # Auto detect text files and perform LF normalization

--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@
 composer.lock
 .phpcs.xml
 phpcs.xml
+.cache/phpcs.cache

--- a/.phpcs.xml.dist
+++ b/.phpcs.xml.dist
@@ -26,6 +26,9 @@
 	<!-- Check up to 8 files simultaneously. -->
 	<arg name="parallel" value="8"/>
 
+	<!-- Cache the results between runs. -->
+	<arg name="cache" value="./.cache/phpcs.cache"/>
+
 
 	<!--
 	#############################################################################

--- a/.travis.yml
+++ b/.travis.yml
@@ -26,6 +26,7 @@ jobs:
 
 cache:
   directories:
+    - .cache
     - vendor
     # Cache directory for older Composer versions.
     - $HOME/.composer/cache/files


### PR DESCRIPTION
Since PHPCS 3.0.0, PHPCS has a caching feature available. In this PR, this caching feature is now turned on for this repo.

This means in effect that the very first run of PHPCS with this feature will be marginally slower (on any individual machine). Most runs _after_ that though, will be significantly faster as PHPCS will only scan the files which have changed since the previous run.

The cache will automatically be invalidated and rebuild whenever relevant, like when the version of one of the PHPCS dependencies has changed or when PHPCS itself has been changed.

To (temporarily) turn caching off, run PHPCS like so:
```bash
composer check-cs -- --no-cache
```

The cache file is set to be saved to a `.cache` directory to allow Travis to benefit from this feature as well.
As this directory _has_ to exist for the cache file to be written to it, it is created and committed to the repo with a `.gitkeep` file

## Commit details:

`/.cache/` directory:
* Create the directory and place a `.gitkeep` file in it to allow it to be committed.

PHPCS config file:
* Enable the caching feature to a fixed file called `/.cache/phpcs.cache`.

`.gitignore`:
* Prevent committing of the cache file.

`.gitattributes`:
* Do not include the `.cache` directory in distributable achives.

Travis:
* Use the Travis caching feature to cache the new `.cache` directory (including the cache file) between runs to allow Travis to benefit from the PHPCS caching as well.

### Testing this PR
* Check out this branch.
* Run `composer check-cs` and take note of the time the run has taken at the bottom of the report.
* Verify that the `.cache` directory on your machine now contains a `phpcs.cache` file.
* Run `composer check-cs` again. If all went well, the run should be significantly faster compared to the earlier run.

Also verify that Travis correctly caches the `.cache` directory. While that won't make a difference for this build, it should for future builds.
