### PR TITLE
Travis/Composer: switch over to parallel linting of PHP files

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -41,7 +41,9 @@ before_install:
 
 install:
 - |
-  if [[ "$PHPCS" == "1" ]]; then
+  if [[ $TRAVIS_PHP_VERSION == "nightly" ]]; then
+    composer install --no-interaction --ignore-platform-reqs
+  else
     composer install --no-interaction
   fi
 
@@ -60,7 +62,7 @@ before_script:
 
 script:
 # PHP Linting
-- find -L . -path ./vendor -prune -o -path ./node_modules -prune -o -name '*.php' -print0 | xargs -0 -n 1 -P 4 php -l
+- composer lint
 
 # PHP CS
 - |

--- a/composer.json
+++ b/composer.json
@@ -25,11 +25,16 @@
     },
     "require-dev": {
         "roave/security-advisories": "dev-master",
-        "yoast/yoastcs": "^2.0.0"
+        "yoast/yoastcs": "^2.0.0",
+        "php-parallel-lint/php-parallel-lint": "^1.2",
+        "php-parallel-lint/php-console-highlighter": "^0.5"
     },
     "minimum-stability": "dev",
     "prefer-stable": true,
     "scripts": {
+        "lint": [
+            "@php ./vendor/php-parallel-lint/php-parallel-lint/parallel-lint . -e php --exclude vendor --exclude node_modules --exclude .git"
+        ],
         "config-yoastcs" : [
             "Dealerdirect\\Composer\\Plugin\\Installers\\PHPCodeSniffer\\Plugin::run",
             "@php ./vendor/squizlabs/php_codesniffer/bin/phpcs --config-set default_standard Yoast"


### PR DESCRIPTION
## Composer

This installs two additional PHP packages in `require-dev`:
* [`php-parallel-lint`](https://packagist.org/packages/jakub-onderka/php-parallel-lint) which allows for linting PHP files in parallel (faster), as well as automatically recursively walking directories.
* [`php-console-highlighter`](https://packagist.org/packages/jakub-onderka/php-console-highlighter) which provides PHP code highlighting in the command line console, allowing the linter to display the results in a more meaningful manner.

It also adds a new `lint` script for use with Composer.

## Travis

* Switch out the script part in the Travis script which did the linting the "old-fashioned" way to use the new Parallel linting option.
* Adjust the `composer install` command in the `install` section to always run.
    As the above mentioned packages are required via Composer, we'll now always need to run `composer install`.
    This should barely slow down the build as the Composer packages are cached by Travis anyway.
* Note: for PHP "nightly" we need to `ignore-platform-reqs` for the time being as one of the PHPCS related dependencies does not allow for installation on PHP 8 yet.
    This has been fixed in the dependency, but there hasn't been a release yet containing the fix.

Ref:
* https://github.com/php-parallel-lint/PHP-Parallel-Lint/releases/tag/v1.2.0
* https://github.com/php-parallel-lint/PHP-Console-Highlighter/releases/tag/v0.5

## Testing this PR

* Check out this branch.
* Run `composer update`.
    If this command gives you any trouble, throw away the `vendor` directory and the `composer.lock` file and run `composer install`.
* Run `composer lint` & see it in action.
* Introduce a parse error in one of the files.
* Run `composer lint` & see the error being reported.
* Undo the parse error.

Also check a couple of the Travis builds to verify that the linting is running and passing.