### PR TITLE
Travis: change from "trusty" to "xenial"

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
+os: linux
 language: php
-dist: trusty
 
 branches:
   only:


### PR DESCRIPTION
As the "trusty" environment is no longer officially supported by Travis, they decided in their wisdom to silently stop updating the PHP "nightly" image, which makes it next to useless as the last image apparently is from January....

This updates the Travis config to:
* Removes the global `dist` key, which will let Travis use the default (`xenial`).
* Makes the expected OS explicit (linux).