### PR TITLE
Composer: update YoastCS to v 2.1.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,7 @@
     },
     "require-dev": {
         "roave/security-advisories": "dev-master",
-        "yoast/yoastcs": "^2.0.0",
+        "yoast/yoastcs": "^2.1.0",
         "php-parallel-lint/php-parallel-lint": "^1.2",
         "php-parallel-lint/php-console-highlighter": "^0.5"
     },


### PR DESCRIPTION
* Update minimum allowed version of YoastCS from `2.0.0` to `2.1.0`.

As this module does not have a committed `composer.lock` file, all other related updates will be pulled in automatically, including version `0.7.0` from the DealerDirect Composer plugin (which is  compatible with Composer 2.0).

Relevant changes in YoastCS:
* The minimum supported WP version has changed to `5.4`.
* A new check for test doubles being named as such.
* A few bugfixes.
* Various sniffs now provide metrics.

Refs:
* https://github.com/Yoast/yoastcs/releases/tag/2.1.0